### PR TITLE
feat: tutorial files open in new tab

### DIFF
--- a/src/features/tutorials/components/tutorial-item/index.tsx
+++ b/src/features/tutorials/components/tutorial-item/index.tsx
@@ -1,6 +1,5 @@
 import { HStack, IconButton, Button } from '@chakra-ui/react';
 import { HiDownload } from 'react-icons/hi';
-import { saveAs } from 'file-saver';
 import { Item } from '@/components/list-item';
 import { ItemActions } from '@/components/list-item/list-item-actions';
 import { Permission } from '@/components/permission';
@@ -14,9 +13,6 @@ export function TutorialItem({ tutorial }: TutorialItemProps) {
   const openFile = (tutorial: Tutorial) => {
     const byteArray = new Uint8Array(tutorial.data.data);
     const blob = new Blob([byteArray], { type: 'application/pdf' });
-    const file = new File([blob], tutorial.filename);
-    saveAs(file, tutorial.filename);
-
     const fileUrl = URL.createObjectURL(blob);
     return fileUrl;
   };

--- a/src/features/tutorials/components/tutorial-item/index.tsx
+++ b/src/features/tutorials/components/tutorial-item/index.tsx
@@ -16,6 +16,14 @@ export function TutorialItem({ tutorial }: TutorialItemProps) {
     const blob = new Blob([byteArray], { type: 'application/pdf' });
     const file = new File([blob], tutorial.filename);
     saveAs(file, tutorial.filename);
+
+    const fileUrl = URL.createObjectURL(blob);
+    return fileUrl;
+  };
+
+  const handleOpenFile = (tutorial: Tutorial) => {
+    const fileUrl = openFile(tutorial);
+    window.open(fileUrl, '_blank');
   };
 
   return (
@@ -31,7 +39,7 @@ export function TutorialItem({ tutorial }: TutorialItemProps) {
         <Permission allowedRoles={['BASIC' || 'USER']}>
           <IconButton
             aria-label="Download Tutorial"
-            onClick={() => openFile(tutorial)}
+            onClick={() => handleOpenFile(tutorial)}
             variant="ghost"
             display="block"
             position="absolute"
@@ -46,7 +54,7 @@ export function TutorialItem({ tutorial }: TutorialItemProps) {
           <Button
             aria-label="Download Tutorial"
             leftIcon={<HiDownload />}
-            onClick={() => openFile(tutorial)}
+            onClick={() => handleOpenFile(tutorial)}
             variant="outline"
             colorScheme="orange"
             color="black"
@@ -61,7 +69,7 @@ export function TutorialItem({ tutorial }: TutorialItemProps) {
         <Permission allowedRoles={['ADMIN']}>
           <IconButton
             aria-label="Download Tutorial"
-            onClick={() => openFile(tutorial)}
+            onClick={() => handleOpenFile(tutorial)}
             variant="ghost"
             display="block"
             position="absolute"
@@ -77,7 +85,7 @@ export function TutorialItem({ tutorial }: TutorialItemProps) {
             <Button
               aria-label="Download Tutorial"
               leftIcon={<HiDownload />}
-              onClick={() => openFile(tutorial)}
+              onClick={() => handleOpenFile(tutorial)}
               variant="outline"
               colorScheme="orange"
               color="black"

--- a/src/features/tutorials/components/tutorial-item/tutorial-item.spec.tsx
+++ b/src/features/tutorials/components/tutorial-item/tutorial-item.spec.tsx
@@ -34,7 +34,7 @@ describe('TutorialItem', () => {
     const { queryByLabelText } = render(
       <TutorialItem
         tutorial={mockedTutorial}
-        {...{ openFile: vi.fn(() => {}) }}
+        {...{ handleOpenFile: vi.fn(() => {}) }}
       />
     );
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->
Este PR serve para adicionar a função extra solicitada pelos clientes de não somente baixar um arquivo de tutorial, mas também abrir o arquivo de tutorial em outra guia do navegador.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->
Resolve tarefa extra da issue [issue #27](https://github.com/fga-eps-mds/2023-1-Schedula-Doc/issues/27)

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
Verificar se a lista de tutoriais disponíveis é gerada.
Ao clicar em "Download", o arquivo .pdf do tutorial deve ser baixado e aberto em outra guia do navegador.

![image](https://github.com/fga-eps-mds/2023-1-schedula-front/assets/48729770/a6335fa3-1120-4a30-aeb6-91a357308d0b)


## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
