### PR TITLE
#25 #27 #28 fix: adjust user permissions

### DIFF
--- a/src/features/tutorials/components/tutorial-item/index.tsx
+++ b/src/features/tutorials/components/tutorial-item/index.tsx
@@ -32,23 +32,22 @@ export function TutorialItem({ tutorial }: TutorialItemProps) {
           </HStack>
         }
       >
-        <Permission allowedRoles={['BASIC' || 'USER']}>
-          <IconButton
-            aria-label="Download Tutorial"
-            onClick={() => handleOpenFile(tutorial)}
-            variant="ghost"
-            display="block"
-            position="absolute"
-            top={0}
-            bottom={0}
-            left={0}
-            right={0}
-            width="100%"
-            height="100%"
-            opacity={0}
-          />
+        <IconButton
+          aria-label="Download Tutorial"
+          onClick={() => handleOpenFile(tutorial)}
+          variant="ghost"
+          display="block"
+          position="absolute"
+          top={0}
+          bottom={0}
+          left={0}
+          right={0}
+          width="100%"
+          height="100%"
+          opacity={0}
+        />
+        <ItemActions item={tutorial}>
           <Button
-            aria-label="Download Tutorial"
             leftIcon={<HiDownload />}
             onClick={() => handleOpenFile(tutorial)}
             variant="outline"
@@ -56,42 +55,10 @@ export function TutorialItem({ tutorial }: TutorialItemProps) {
             color="black"
             borderColor="transparent"
             borderWidth={0}
-            marginTop="20px"
           >
             Download
           </Button>
-        </Permission>
-
-        <Permission allowedRoles={['ADMIN']}>
-          <IconButton
-            aria-label="Download Tutorial"
-            onClick={() => handleOpenFile(tutorial)}
-            variant="ghost"
-            display="block"
-            position="absolute"
-            top={0}
-            bottom={0}
-            left={0}
-            right={0}
-            width="100%"
-            height="100%"
-            opacity={0}
-          />
-          <ItemActions item={tutorial}>
-            <Button
-              aria-label="Download Tutorial"
-              leftIcon={<HiDownload />}
-              onClick={() => handleOpenFile(tutorial)}
-              variant="outline"
-              colorScheme="orange"
-              color="black"
-              borderColor="transparent"
-              borderWidth={0}
-            >
-              Download
-            </Button>
-          </ItemActions>
-        </Permission>
+        </ItemActions>
       </Item>
     </div>
   );

--- a/src/features/tutorials/components/tutorial-item/tutorial-item.spec.tsx
+++ b/src/features/tutorials/components/tutorial-item/tutorial-item.spec.tsx
@@ -39,8 +39,6 @@ describe('TutorialItem', () => {
     );
 
     const downloadButton = queryByLabelText('Download Tutorial');
-    if (downloadButton) {
-      expect(downloadButton).toBeInTheDocument();
-    }
+    expect(downloadButton).toBeInTheDocument();
   });
 });

--- a/src/pages/tutoriais/index.tsx
+++ b/src/pages/tutoriais/index.tsx
@@ -21,6 +21,7 @@ import {
   chakraStyles,
   customComponents,
 } from '@/components/form-fields/controlled-select/styles';
+import { Permission } from '@/components/permission';
 
 export function Tutoriais() {
   const { data: tutorials, isLoading } = useGetallTutorials();
@@ -107,19 +108,21 @@ export function Tutoriais() {
   return (
     <>
       <PageHeader title="Tutoriais">
-        <Button
-          variant="primary"
-          onClick={() => navigate('categorias_de_tutorial')}
-        >
-          Gerenciamento de categorias
-        </Button>
-        <Button
-          variant="primary"
-          onClick={() => navigate('gerenciar-tutorial')}
-          style={{ marginLeft: 30 }}
-        >
-          Gerenciar tutoriais
-        </Button>
+        <Permission allowedRoles={['ADMIN']}>
+          <Button
+            variant="primary"
+            onClick={() => navigate('categorias_de_tutorial')}
+          >
+            Gerenciamento de categorias
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => navigate('gerenciar-tutorial')}
+            style={{ marginLeft: 30 }}
+          >
+            Gerenciar tutoriais
+          </Button>
+        </Permission>
       </PageHeader>
 
       <Grid templateColumns="repeat(2, 1fr)" gap={8} marginBottom="4">


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->
Este PR serve para ajustar, após feito todo o merge das US, a dinâmica de permissão de visualização dos botões que levam ao gerenciamento de categorias e tutoriais, na página de acesso a tutoriais. Somente usuários do nível admin devem visualizá-los.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->
Resolve tarefa que une as issues [#25](https://github.com/fga-eps-mds/2023-1-Schedula-Doc/issues/25), [#27](https://github.com/fga-eps-mds/2023-1-Schedula-Doc/issues/27) e [#28](https://github.com/fga-eps-mds/2023-1-Schedula-Doc/issues/28)

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
Verificar se os botões de acesso que levam ao gerenciamento de categorias e tutoriais aparecem somente a usuários do nível admin.

![image](https://github.com/fga-eps-mds/2023-1-schedula-front/assets/48729770/41bbad1b-cfe2-4dbc-aea8-9ba34f6434b6)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
