### PR TITLE
#98 bug descricao agendamentos

### DIFF
--- a/src/features/schedules/components/schedule-item/index.tsx
+++ b/src/features/schedules/components/schedule-item/index.tsx
@@ -100,7 +100,9 @@ export function ScheduleItem({
               </Text>
               {isExpanded ? (
                 <Box maxWidth="110ch">
-                  <Text noOfLines={undefined}>{schedule.description}</Text>
+                  <Text noOfLines={undefined} textAlign="justify">
+                    {schedule.description}
+                  </Text>
                 </Box>
               ) : (
                 <Text noOfLines={1}>

--- a/src/features/schedules/components/schedule-item/index.tsx
+++ b/src/features/schedules/components/schedule-item/index.tsx
@@ -1,12 +1,15 @@
 import {
   Badge,
   Box,
+  Button,
+  Collapse,
   HStack,
   Spacer,
   Tag,
   Text,
   VStack,
 } from '@chakra-ui/react';
+import { useState } from 'react';
 import { formatDate } from '@/utils/format-date';
 import { Item } from '@/components/list-item';
 import { Schedule } from '@/features/schedules/types';
@@ -46,6 +49,8 @@ export function ScheduleItem({
         return 'green';
     }
   }
+
+  const [isExpanded, setIsExpanded] = useState(false);
 
   return (
     <Box>
@@ -94,7 +99,27 @@ export function ScheduleItem({
               <Text fontSize="sm" fontWeight="light" color="GrayText">
                 Descrição:
               </Text>
-              <Text noOfLines={1}>{schedule.description}</Text>
+              {isExpanded ? (
+                <Box maxWidth="110ch">
+                  <Text noOfLines={undefined}>{schedule.description}</Text>
+                </Box>
+              ) : (
+                <Text noOfLines={1}>
+                  {schedule.description.length > 110
+                    ? `${schedule.description.substring(0, 110)}...`
+                    : schedule.description}
+                </Text>
+              )}
+              {schedule.description.length > 110 && (
+                <Button
+                  size="xs"
+                  variant="link"
+                  colorScheme="blue"
+                  onClick={() => setIsExpanded(!isExpanded)}
+                >
+                  {isExpanded ? 'Mostrar menos' : 'Mostrar mais'}
+                </Button>
+              )}
             </Box>
           </VStack>
         }

--- a/src/features/schedules/components/schedule-item/index.tsx
+++ b/src/features/schedules/components/schedule-item/index.tsx
@@ -2,7 +2,6 @@ import {
   Badge,
   Box,
   Button,
-  Collapse,
   HStack,
   Spacer,
   Tag,

--- a/src/features/schedules/components/schedule-item/schedule-item.spec.tsx
+++ b/src/features/schedules/components/schedule-item/schedule-item.spec.tsx
@@ -1,0 +1,230 @@
+import { fireEvent, render } from '@testing-library/react';
+import { vi } from 'vitest';
+import { ScheduleItem } from '@/features/schedules/components/schedule-item';
+import { Schedule, ScheduleStatus } from '@/features/schedules/types';
+
+const mockedSchedule: Schedule = {
+  id: '1',
+  dateTime: '2021-10-10T10:00:00',
+  description:
+    'Lorem Ipsum is simply dummy text of the printing and typesetting industry',
+  status: ScheduleStatus.NOT_RESOLVED,
+  alerts: [
+    {
+      id: '1',
+      date: '2021-10-10',
+    },
+  ],
+  issue: {
+    id: '1',
+    requester: 'Mockerson',
+    phone: '61988554474',
+    city_id: '123',
+    workstation_id: '123',
+    email: 'mcok@email.com',
+    date: '2021-10-10',
+    problem_category: {
+      id: '1',
+      name: 'Category Mock',
+      description: 'Category Mock',
+      problem_types: [
+        {
+          id: '1',
+          name: 'Type Mock',
+        },
+      ],
+    },
+    problem_types: [
+      {
+        id: '1',
+        name: 'Type Mock',
+      },
+    ],
+  },
+};
+
+const mockedScheduleProgress = {
+  ...mockedSchedule,
+  status: ScheduleStatus.PROGRESS,
+};
+
+const mockedSchedulePendent = {
+  ...mockedSchedule,
+  status: ScheduleStatus.PENDENT,
+};
+
+const mockedScheduleUrgent = {
+  ...mockedSchedule,
+  status: ScheduleStatus.URGENT,
+};
+
+const mockedScheduleResolved = {
+  ...mockedSchedule,
+  status: ScheduleStatus.RESOLVED,
+};
+
+const mockedScheduleDescription = {
+  ...mockedSchedule,
+  description:
+    'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy',
+};
+
+const mockedOnEditFunction = vi.fn(() => {});
+const mockedOnDeleteFunction = vi.fn((scheduleId: string) => scheduleId);
+
+describe('ScheduleItem', () => {
+  it('should display the status NOT_RESOLVED of the schedule correctly', async () => {
+    const { findAllByText } = render(
+      <ScheduleItem
+        schedule={mockedSchedule}
+        isDeleting={false}
+        onEdit={mockedOnEditFunction}
+        onDelete={mockedOnDeleteFunction}
+      />
+    );
+
+    const status = await findAllByText(mockedSchedule.status);
+    expect(status[0]).toBeInTheDocument();
+  });
+
+  it('should display the status PROGRESS of the schedule correctly', async () => {
+    const { findAllByText } = render(
+      <ScheduleItem
+        schedule={mockedScheduleProgress}
+        isDeleting={false}
+        onEdit={mockedOnEditFunction}
+        onDelete={mockedOnDeleteFunction}
+      />
+    );
+
+    const status = await findAllByText(mockedScheduleProgress.status);
+    expect(status[0]).toBeInTheDocument();
+  });
+
+  it('should display the status PENDENT of the schedule correctly', async () => {
+    const { findAllByText } = render(
+      <ScheduleItem
+        schedule={mockedSchedulePendent}
+        isDeleting={false}
+        onEdit={mockedOnEditFunction}
+        onDelete={mockedOnDeleteFunction}
+      />
+    );
+
+    const status = await findAllByText(mockedSchedulePendent.status);
+    expect(status[0]).toBeInTheDocument();
+  });
+
+  it('should display the status URGENT of the schedule correctly', async () => {
+    const { findAllByText } = render(
+      <ScheduleItem
+        schedule={mockedScheduleUrgent}
+        isDeleting={false}
+        onEdit={mockedOnEditFunction}
+        onDelete={mockedOnDeleteFunction}
+      />
+    );
+
+    const status = await findAllByText(mockedScheduleUrgent.status);
+    expect(status[0]).toBeInTheDocument();
+  });
+
+  it('should display the status RESOLVED of the schedule correctly', async () => {
+    const { findAllByText } = render(
+      <ScheduleItem
+        schedule={mockedScheduleResolved}
+        isDeleting={false}
+        onEdit={mockedOnEditFunction}
+        onDelete={mockedOnDeleteFunction}
+      />
+    );
+
+    const status = await findAllByText(mockedScheduleResolved.status);
+    expect(status[0]).toBeInTheDocument();
+  });
+
+  it('should display the description with less than 110 characters of the schedule correctly', async () => {
+    const { findAllByText } = render(
+      <ScheduleItem
+        schedule={mockedSchedule}
+        isDeleting={false}
+        onEdit={mockedOnEditFunction}
+        onDelete={mockedOnDeleteFunction}
+      />
+    );
+
+    const description = await findAllByText(mockedSchedule.description);
+    expect(description[0]).toBeInTheDocument();
+  });
+
+  it('should display the description with more than 110 characters and no expanded of the schedule correctly', async () => {
+    const { findAllByText } = render(
+      <ScheduleItem
+        schedule={mockedScheduleDescription}
+        isDeleting={false}
+        onEdit={mockedOnEditFunction}
+        onDelete={mockedOnDeleteFunction}
+      />
+    );
+
+    const description = await findAllByText(
+      `${mockedScheduleDescription.description.substring(0, 110)}...`
+    );
+    expect(description[0]).toBeInTheDocument();
+  });
+
+  it('should display the description with more than 110 characters and expanded of the schedule correctly', async () => {
+    const { findAllByText, findByText } = render(
+      <ScheduleItem
+        schedule={mockedScheduleDescription}
+        isDeleting={false}
+        onEdit={mockedOnEditFunction}
+        onDelete={mockedOnDeleteFunction}
+      />
+    );
+
+    const showMoreButton = await findByText('Mostrar mais');
+    fireEvent.click(showMoreButton);
+
+    const expandedDescription = await findAllByText(
+      mockedScheduleDescription.description
+    );
+    expect(expandedDescription[0]).toBeInTheDocument();
+  });
+
+  it('should be able to edit a schedule', async () => {
+    const { queryByLabelText } = render(
+      <ScheduleItem
+        schedule={mockedSchedule}
+        isDeleting={false}
+        onEdit={mockedOnEditFunction}
+        onDelete={mockedOnDeleteFunction}
+      />
+    );
+
+    const EditButton = await queryByLabelText(
+      `Editar ${mockedSchedule.status}`
+    );
+    if (EditButton) {
+      fireEvent.click(EditButton);
+      expect(mockedOnEditFunction).toHaveBeenCalled();
+    }
+  });
+
+  it('should be able to delete a schedule', async () => {
+    const { queryByLabelText } = render(
+      <ScheduleItem
+        schedule={mockedSchedule}
+        isDeleting={false}
+        onEdit={mockedOnEditFunction}
+        onDelete={mockedOnDeleteFunction}
+      />
+    );
+
+    const deleteButton = queryByLabelText(`Excluir Agendamento`);
+    if (deleteButton) {
+      fireEvent.click(deleteButton);
+      expect(mockedOnDeleteFunction).toHaveBeenCalledWith(mockedSchedule.id);
+    }
+  });
+});


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Resolvendo o bug do campo de descrição na tela de agendamentos.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

Resolve [Issue #98](https://github.com/fga-eps-mds/2023-1-Schedula-Doc/issues/98)

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

Agora há um limite máximo de caracteres (110) que será mostrada no card, caso a descrição ultrapasse esse limite, irá aparecer a mensagem 'Mostrar mais' para o usuário ler o restante da descrição.

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Criar um agendamento com mais de 110 caracteres, para testar que a mensagem 'Mostrar mais' irá aparecer
![image](https://github.com/fga-eps-mds/2023-1-schedula-front/assets/46847658/54fe3cad-2c9f-4e2b-b2a6-d98e9264db8b)

Testar que depois de pressionado o 'Mostrar mais' o card será expandido
![image](https://github.com/fga-eps-mds/2023-1-schedula-front/assets/46847658/51299b91-9f44-4b5d-a3c4-177457ab72ff)
Após expandido o card verificar se aparece a mensagem 'Mostrar menos'  e testar que depois de pressionado o card volta para o tamanho normal, escondendo a mensagem.

Criar um agendamento com menos de 110 caracteres, para testar que a mensagem 'Mostrar mais' não irá aparecer
![image](https://github.com/fga-eps-mds/2023-1-schedula-front/assets/46847658/8690be38-bfc3-424d-a541-4bf48ad4e1d5)

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
