### PR TITLE
#113 categorias tipos problema usuario externo

### DIFF
--- a/src/components/forms/categoria-form/categoria-form.spec.tsx
+++ b/src/components/forms/categoria-form/categoria-form.spec.tsx
@@ -6,6 +6,7 @@ const category: Category = {
   id: '1',
   description: 'Descrição da Categoria',
   name: 'Categoria',
+  visible_user_external: false,
 };
 
 describe('CategoriaForm', () => {

--- a/src/features/problem/api/types.ts
+++ b/src/features/problem/api/types.ts
@@ -1,18 +1,21 @@
 export interface ProblemTypeOption {
   id: string;
   name: string;
+  visible_user_external: boolean;
 }
 
 export interface ProblemCategory {
   id: string;
   name: string;
   description: string;
+  visible_user_external: boolean;
   problem_types: ProblemTypeOption[];
 }
 
 export interface PostCreateProblemCategoryParams {
   name: string;
   description: string;
+  visible_user_external: boolean;
   problem_types_ids?: string[];
 }
 
@@ -20,6 +23,7 @@ export interface PostCreateProblemCategoryResponse {
   id: string;
   name: string;
   description: string;
+  visible_user_external: boolean;
   problem_types: ProblemTypeOption[];
 }
 
@@ -28,6 +32,7 @@ export interface PutUpdateProblemCategoriesParams {
   data: {
     name: string;
     description: string;
+    visible_user_external: boolean;
     problem_types_ids?: string[];
   };
 }
@@ -36,6 +41,7 @@ export interface PutUpdateProblemCategoriesResponse {
   id: string;
   name: string;
   description: string;
+  visible_user_external: boolean;
   problem_types: ProblemTypeOption[];
 }
 
@@ -51,5 +57,6 @@ export interface GetProblemCategoryResponse {
   id: string;
   name: string;
   description: string;
+  visible_user_external: boolean;
   problem_types: [];
 }

--- a/src/features/problem/problem-categories/components/categoria-form/index.tsx
+++ b/src/features/problem/problem-categories/components/categoria-form/index.tsx
@@ -1,5 +1,5 @@
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { Button, VStack } from '@chakra-ui/react';
+import { Button, VStack, Checkbox } from '@chakra-ui/react';
 
 import { Input } from '@/components/form-fields';
 
@@ -33,6 +33,14 @@ export function CategoriaForm({ defaultValues, onSubmit }: CategoriaFormProps) {
           {...register('description')}
           errors={errors?.description}
         />
+        <Checkbox
+          size="md"
+          width="full"
+          colorScheme="orange"
+          {...register('visible_user_external')}
+        >
+          Visível para usuário externo
+        </Checkbox>
         <Button type="submit" size="lg" width="100%" isLoading={isSubmitting}>
           Registrar
         </Button>

--- a/src/features/problem/problem-categories/components/category-modal/category-modal.tsx
+++ b/src/features/problem/problem-categories/components/category-modal/category-modal.tsx
@@ -27,19 +27,21 @@ export function CategoryModal({
   } = usePutUpdateProblemCategory({});
 
   const handleSubmit = useCallback(
-    ({ name, description }: CategoryPayload) => {
+    ({ name, description, visible_user_external }: CategoryPayload) => {
       if (category?.id) {
         updateProblemCategory({
           id: category.id,
           data: {
             name,
             description,
+            visible_user_external,
           },
         });
       } else {
         createProblemCategory({
           name,
           description,
+          visible_user_external,
         });
       }
 

--- a/src/features/problem/problem-types/api/types.ts
+++ b/src/features/problem/problem-types/api/types.ts
@@ -1,5 +1,6 @@
 export interface PostCreateProblemTypeParams {
   name: string;
+  visible_user_external: boolean;
   problem_category_id: string;
   issues_ids?: string[];
 }
@@ -7,6 +8,7 @@ export interface PostCreateProblemTypeParams {
 export interface PostCreateProblemTypeResponse {
   id: string;
   name: string;
+  visible_user_external: boolean;
   description: string;
 }
 
@@ -14,6 +16,7 @@ export interface PutUpdateProblemTypeParams {
   id: string;
   data: {
     name: string;
+    visible_user_external: boolean;
     problem_category_id: string;
     issues_ids?: string[];
   };
@@ -22,6 +25,7 @@ export interface PutUpdateProblemTypeParams {
 export interface PutUpdateProblemTypeResponse {
   id: string;
   name: string;
+  visible_user_external: boolean;
   description: string;
 }
 

--- a/src/features/problem/problem-types/components/problem-type-form/index.tsx
+++ b/src/features/problem/problem-types/components/problem-type-form/index.tsx
@@ -1,5 +1,5 @@
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { Button, VStack } from '@chakra-ui/react';
+import { Button, VStack, Checkbox } from '@chakra-ui/react';
 
 import { Input } from '@/components/form-fields';
 import {
@@ -32,6 +32,14 @@ export function ProblemForm({ defaultValues, onSubmit }: ProblemFormProps) {
           })}
           errors={errors?.name}
         />
+        <Checkbox
+          size="md"
+          width="full"
+          colorScheme="orange"
+          {...register('visible_user_external')}
+        >
+          Visível para usuário externo
+        </Checkbox>
         <Button type="submit" size="lg" width="100%" isLoading={isSubmitting}>
           Registrar
         </Button>

--- a/src/features/problem/problem-types/components/problem-type-modal/index.tsx
+++ b/src/features/problem/problem-types/components/problem-type-modal/index.tsx
@@ -29,18 +29,20 @@ export function ProblemTypeModal({
     usePutUpdateProblemType({});
 
   const handleSubmit = useCallback(
-    async ({ name }: ProblemTypePayload) => {
+    async ({ name, visible_user_external }: ProblemTypePayload) => {
       if (problemType) {
         updateProblemType({
           id: problemType.id,
           data: {
             name,
+            visible_user_external,
             problem_category_id: categoryId,
           },
         });
       } else {
         createProblemType({
           name,
+          visible_user_external,
           problem_category_id: categoryId,
         });
       }

--- a/src/features/problem/problem-types/types.ts
+++ b/src/features/problem/problem-types/types.ts
@@ -1,6 +1,7 @@
 export interface ProblemType {
   id: string;
   name: string;
+  visible_user_external: boolean;
   description: string;
   category_id: number;
   active: boolean;
@@ -9,4 +10,5 @@ export interface ProblemType {
 
 export interface ProblemTypePayload {
   name: string;
+  visible_user_external: boolean;
 }

--- a/src/pages/categorias/categories.spec.tsx
+++ b/src/pages/categorias/categories.spec.tsx
@@ -2,12 +2,15 @@ import { ChakraProvider } from '@chakra-ui/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
+import { vi } from 'vitest';
 import { theme } from '@/styles/theme';
 import ProblemCategories from '@/pages/categorias';
 import { AuthProvider } from '@/contexts/AuthContext';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import 'intersection-observer';
+import { ProblemCategory } from '@/features/problem/api/types';
+import { CategoryItem } from '@/features/problem/problem-categories/components/category-item';
 
 describe('Categories Page', () => {
   const queryClient = new QueryClient();
@@ -29,5 +32,32 @@ describe('Categories Page', () => {
     if (btn) {
       expect(btn).toBeInTheDocument();
     }
+  });
+
+  it('renders category item correctly', () => {
+    const category: ProblemCategory = {
+      id: '1',
+      name: 'Categoria de exemplo',
+      description: 'Desc',
+      visible_user_external: false,
+      problem_types: [],
+    };
+
+    const mockedOnEditFunction = vi.fn(() => {});
+    const mockedOnDeleteFunction = vi.fn((categoryId: string) => categoryId);
+    const isRemovingProblemCategory = false;
+
+    const { getByText } = render(
+      <BrowserRouter>
+        <CategoryItem
+          category={category}
+          onEdit={mockedOnEditFunction}
+          onDelete={mockedOnDeleteFunction}
+          isDeleting={isRemovingProblemCategory}
+        />
+      </BrowserRouter>
+    );
+
+    expect(getByText('Categoria de exemplo')).toBeInTheDocument();
   });
 });

--- a/src/pages/categorias/index.tsx
+++ b/src/pages/categorias/index.tsx
@@ -48,7 +48,7 @@ function ProblemCategories() {
     (category: ProblemCategory) => (
       <CategoryItem
         category={category}
-        onEdit={onEdit}
+        onEdit={() => onEdit(category)}
         onDelete={onDelete}
         isDeleting={isRemovingProblemCategory}
       />

--- a/src/types/categoria.d.ts
+++ b/src/types/categoria.d.ts
@@ -2,9 +2,11 @@ interface Category {
   id: string;
   description: string;
   name: string;
+  visible_user_external: boolean;
 }
 
 interface CategoryPayload {
   name: string;
   description: string;
+  visible_user_external: boolean;
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description
Arrumando a edição de categoria de problema e permitindo marcar se uma categoria ou tipo de problema pode ser visualizado por um usuário externo.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues
Resolve [Issue #113](https://github.com/fga-eps-mds/2023-1-Schedula-Doc/issues/113)
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes
Agora é possível editar uma categoria de problema.
Agora é possível marcar se uma categoria ou tipo de problema pode ser visualizado por usuário externo.
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan
Utilizar a branch "#113-Categorias_Tipos_Problema_Usuario_Externo" no micro serviço de chamados.
Editar uma categoria de problema.
Adicionar, editar e excluir categoria de problema e tipo de problema, manipulando o checkbox de visualização por usuário externo.
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
