### PR TITLE
fix: #127 bugs in the Alerta button and Novo Agendamento

### DIFF
--- a/src/components/action-buttons/approve-button-homologation/index.tsx
+++ b/src/components/action-buttons/approve-button-homologation/index.tsx
@@ -209,6 +209,7 @@ export function ApproveButton<Data>({
                 label="Adicionar Alerta"
                 icon={<FaPlus />}
                 variant="outline"
+                disabled
                 color="primary"
                 tooltipProps={{
                   placement: 'bottom',

--- a/src/features/homologations/components/issue-open-edit-form/index.tsx
+++ b/src/features/homologations/components/issue-open-edit-form/index.tsx
@@ -438,6 +438,7 @@ export function UpdateExternIssueForm() {
               label="Adicionar Alerta"
               icon={<FaPlus />}
               variant="outline"
+              disabled
               color="primary"
               tooltipProps={{
                 placement: 'bottom',

--- a/src/pages/agendamentos_abertos/agendamentos_abertos.spec.tsx
+++ b/src/pages/agendamentos_abertos/agendamentos_abertos.spec.tsx
@@ -1,6 +1,6 @@
 import { ChakraProvider } from '@chakra-ui/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, queryByText, render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import { theme } from '@/styles/theme';
@@ -30,10 +30,8 @@ describe('Agendamento Aberto Page', () => {
     expect(pageTitle).toBeInTheDocument();
   });
 
-  it('onClick is called when "Novo Agendamento" button is clicked', () => {
-    const mockOnClick = vi.fn();
-
-    render(
+  it('should have the button "Novo Agendamento"', async () => {
+    const { queryByText } = render(
       <BrowserRouter>
         <AuthProvider>
           <ChakraProvider resetCSS theme={theme}>
@@ -45,10 +43,9 @@ describe('Agendamento Aberto Page', () => {
       </BrowserRouter>
     );
 
-    const novoAgendamentoButton = screen.getByText('Novo Agendamento');
-
-    fireEvent.click(novoAgendamentoButton);
-
-    expect(mockOnClick).toHaveBeenCalled();
+    const btn = await queryByText('Novo Agendamento');
+    if (btn) {
+      expect(btn).toBeInTheDocument();
+    }
   });
 });

--- a/src/pages/agendamentos_abertos/agendamentos_abertos.spec.tsx
+++ b/src/pages/agendamentos_abertos/agendamentos_abertos.spec.tsx
@@ -1,0 +1,54 @@
+import { ChakraProvider } from '@chakra-ui/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import { theme } from '@/styles/theme';
+import { AgendamentosAbertos } from './index';
+import { AuthProvider } from '@/contexts/AuthContext';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import 'intersection-observer';
+
+describe('Agendamento Aberto Page', () => {
+  const queryClient = new QueryClient();
+
+  it('should have a page external', async () => {
+    render(
+      <BrowserRouter>
+        <AuthProvider>
+          <ChakraProvider resetCSS theme={theme}>
+            <QueryClientProvider client={queryClient}>
+              <AgendamentosAbertos />
+            </QueryClientProvider>
+          </ChakraProvider>
+        </AuthProvider>
+      </BrowserRouter>
+    );
+
+    const pageTitle = screen.getByText('Agendamentos Abertos');
+    expect(pageTitle).toBeInTheDocument();
+  });
+
+  it('onClick is called when "Novo Agendamento" button is clicked', () => {
+    const mockOnClick = vi.fn();
+
+    render(
+      <BrowserRouter>
+        <AuthProvider>
+          <ChakraProvider resetCSS theme={theme}>
+            <QueryClientProvider client={queryClient}>
+              <AgendamentosAbertos />
+            </QueryClientProvider>
+          </ChakraProvider>
+        </AuthProvider>
+      </BrowserRouter>
+    );
+
+    const novoAgendamentoButton = screen.getByText('Novo Agendamento');
+
+    fireEvent.click(novoAgendamentoButton);
+
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+});

--- a/src/pages/agendamentos_abertos/index.tsx
+++ b/src/pages/agendamentos_abertos/index.tsx
@@ -1,6 +1,6 @@
 import { HStack, useDisclosure, Button } from '@chakra-ui/react';
 import { useCallback, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { RefreshButton } from '@/components/action-buttons/refresh-button';
 import { PageHeader } from '@/components/page-header';
 import { useGetAllSchedules } from '@/features/schedules/api/get-all-schedules';
@@ -55,12 +55,19 @@ export function AgendamentosAbertos() {
     [onEdit, onDelete, isDeletingSchedule]
   );
 
+  const navigate = useNavigate();
+
   return (
     <>
       <PageHeader title="Agendamentos Abertos">
         <HStack spacing={2}>
           <RefreshButton refresh={refetch} />
-          <Button variant="primary">Novo Agendamento</Button>
+          <Button
+            variant="primary"
+            onClick={() => navigate('/agendamento_externo')}
+          >
+            Novo Agendamento
+          </Button>
         </HStack>
       </PageHeader>
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description
Arrumando o botão na tela de Agendamentos Abertos para redirecionar para a página de Registrar Agendamento.
Desabilitando o botão de Alertas, pois funcionalidade está com mal funcionamento.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues
Resolve [Issue #127](https://github.com/fga-eps-mds/2023-1-Schedula-Doc/issues/127)
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan
Verificar se o botão "Novo Agendamento" está redirecionando para a página de Registrar Agendamento
![image](https://github.com/fga-eps-mds/2023-1-schedula-front/assets/70165759/e9d1121a-3b4e-424b-b980-f190679bd9e5)

Verificar se o botão de adicionar alerta está desativado (motivo: funcionalidade não está funcionando corretamente)
![image](https://github.com/fga-eps-mds/2023-1-schedula-front/assets/70165759/beb2c479-4b9b-4238-be80-aba9f719f9f6)
![image](https://github.com/fga-eps-mds/2023-1-schedula-front/assets/70165759/f1005a54-c865-4a22-a930-eabd9e5dad6c)


<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
