### PR TITLE
#91 agendamento de atendimento

### DIFF
--- a/src/features/issues/components/issue-item/index.tsx
+++ b/src/features/issues/components/issue-item/index.tsx
@@ -1,6 +1,7 @@
 import {
   Badge,
   Box,
+  Button,
   HStack,
   Spacer,
   Tag,
@@ -19,9 +20,15 @@ interface IssueItemProps {
   issue: Issue;
   onDelete: (issueId: string) => void;
   isDeleting: boolean;
+  onOpen?: () => void;
 }
 
-export function IssueItem({ issue, onDelete, isDeleting }: IssueItemProps) {
+export function IssueItem({
+  issue,
+  onDelete,
+  isDeleting,
+  onOpen,
+}: IssueItemProps) {
   const { data: cities } = useGetAllCities(0);
   const city = cities?.find((city) => {
     return city?.id === issue?.city_id;
@@ -107,6 +114,8 @@ export function IssueItem({ issue, onDelete, isDeleting }: IssueItemProps) {
                   }}
                 >
                   <ItemActions item={city}>
+                    <Button onClick={onOpen}>Gerar Agendamento</Button>
+
                     <DeleteButton
                       onClick={() => onDelete(issue.id)}
                       label="atendimento"

--- a/src/features/issues/components/issue-item/index.tsx
+++ b/src/features/issues/components/issue-item/index.tsx
@@ -15,6 +15,7 @@ import { useGetAllCities } from '@/features/cities/api/get-all-cities';
 import { DeleteButton } from '@/components/action-buttons/delete-button';
 import { ItemActions } from '@/components/list-item/list-item-actions';
 import { Permission } from '@/components/permission';
+import { useGetAllSchedules } from '@/features/schedules/api/get-all-schedules';
 
 interface IssueItemProps {
   issue: Issue;
@@ -33,6 +34,12 @@ export function IssueItem({
   const city = cities?.find((city) => {
     return city?.id === issue?.city_id;
   });
+
+  const { data: schedules } = useGetAllSchedules();
+
+  const isIssueScheduled = schedules?.some(
+    (schedule) => schedule.issue.id === issue.id
+  );
 
   return (
     <Box>
@@ -114,7 +121,11 @@ export function IssueItem({
                   }}
                 >
                   <ItemActions item={city}>
-                    <Button onClick={onOpen}>Gerar Agendamento</Button>
+                    {!isIssueScheduled ? (
+                      <Button onClick={onOpen}>Gerar Agendamento</Button>
+                    ) : (
+                      (null as any)
+                    )}
 
                     <DeleteButton
                       onClick={() => onDelete(issue.id)}

--- a/src/features/schedules/components/schedule-form/index.tsx
+++ b/src/features/schedules/components/schedule-form/index.tsx
@@ -79,9 +79,8 @@ export function ScheduleForm({
           applicant_phone={issue?.phone ?? ''}
           city={city?.name ?? ''}
           problem={
-            issue?.problem_category.problem_types
-              .map((problem) => problem.name)
-              .join(' - ') ?? ''
+            issue?.problem_types.map((problem) => problem.name).join(' - ') ??
+            ''
           }
           category={issue?.problem_category.name ?? ''}
           workstation={workstation ?? ''}

--- a/src/pages/chamados/index.tsx
+++ b/src/pages/chamados/index.tsx
@@ -1,6 +1,6 @@
-import { Button, HStack } from '@chakra-ui/react';
+import { Button, HStack, useDisclosure } from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { RefreshButton } from '@/components/action-buttons/refresh-button';
 import { PageHeader } from '@/components/page-header';
 import { useGetAllIssues } from '@/features/issues/api/get-all-issues';
@@ -9,6 +9,7 @@ import { Permission } from '@/components/permission';
 import { ListView } from '@/components/list';
 import { IssueItem } from '@/features/issues/components/issue-item';
 import { useDeleteIssue } from '@/features/issues/api/delete-issue';
+import { ScheduleModal } from '@/features/schedules/components/schedule-modal';
 
 export function sortIssues(issues: Issue[] | undefined): Issue[] {
   if (!issues) {
@@ -40,15 +41,28 @@ export function Chamados() {
     [deleteIssue]
   );
 
+  const [issueToCreate, setIssueToCreate] = useState<Issue>();
+
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const onCreate = useCallback(
+    (issue: Issue) => {
+      setIssueToCreate(issue);
+      onOpen();
+    },
+    [onOpen]
+  );
+
   const renderIssueItem = useCallback(
     (issue: Issue) => (
       <IssueItem
         issue={issue}
         onDelete={onDelete}
         isDeleting={isRemovingIssue}
+        onOpen={() => onCreate(issue)}
       />
     ),
-    [onDelete, isRemovingIssue]
+    [onDelete, isRemovingIssue, onCreate]
   );
 
   return (
@@ -69,6 +83,8 @@ export function Chamados() {
         render={renderIssueItem}
         isLoading={isLoadingIssues}
       />
+
+      <ScheduleModal issue={issueToCreate} isOpen={isOpen} onClose={onClose} />
     </>
   );
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Adicionando um botão no card do atendimento para que ele possa virar um agendamento. Tal botão só é renderizado quando esse atendimento já não for um agendamento.

### 🎫 Issues

[US91 - Agendamento de atendimento](https://github.com/fga-eps-mds/2023-1-Schedula-Doc/issues/91)

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

1. Apertar no botão e preencher as informações para verificar se ele está conseguindo agendar com sucesso.
2. Verificar se os atendimentos que já são agendamentos não estão com o botão renderizados.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
